### PR TITLE
Fix(CI): Install libtinfo5 to fix GHC error

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -18,8 +18,13 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.8.1
         with:
-          bazel-version: 6.5.0
+          bazel-version: 7.4.0
           repository-cache: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libtinfo5
 
       - name: Build all targets
         run: bazel build //...

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -18,13 +18,18 @@ jobs:
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.8.1
         with:
-          bazel-version: 7.4.0
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ github.workflow }}
+          # Share repository cache between workflows.
           repository-cache: true
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libtinfo5
+          wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          sudo apt install -y ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
 
       - name: Build all targets
         run: bazel build //...


### PR DESCRIPTION
This PR fixes the CI build by installing the `libtinfo5` dependency, which is required by GHC.